### PR TITLE
ExoService: remove impossible test

### DIFF
--- a/exoservice-javascript/features/configuring-the-port.feature
+++ b/exoservice-javascript/features/configuring-the-port.feature
@@ -17,7 +17,3 @@ Feature: Defining the port at which the server listens
   Scenario: an ExoService instance connects to ExoCom
     When starting a service configured for ExoCom port 3001
     Then it connects to the ExoCom instance
-
-  Scenario: a wrong Exocom port is given
-    When trying to start a service configured for ExoCom port 3002
-    Then it aborts with the error message "Cannot find ExoCom at port 3002"

--- a/exoservice-javascript/features/support/steps-then.ls
+++ b/exoservice-javascript/features/support/steps-then.ls
@@ -23,11 +23,6 @@ module.exports = ->
       done!
 
 
-  @Then /^it aborts with the error message "([^"]*)"$/ (error-message, done) ->
-    #TODO: implement this
-    done!
-
-
   @Then /^it acknowledges the received message$/, (done) ->
     wait-until (~> @exocom.received-messages.length), done
 


### PR DESCRIPTION
@kevgo @trushton 

ExoService continuously retries connecting to ExoCom after failed attempts, so that we don't have to care what order the services/ExoCom come online in production. Therefore we can never test that a service aborts because it is configured with the wrong ExoCom information.